### PR TITLE
Added required "main" property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "ember-sockets",
   "version": "0.5.0",
   "homepage": "https://github.com/Wildhoney/EmberSockets",
+  "main": "dist/ember-sockets.min.js",
   "authors": [
     "Adam Timberlake <adam.timberlake@gmail.com>"
   ],


### PR DESCRIPTION
The "main" property is required for build tools like brunch or grunt otherwise you get errors like this:

```
25 Mar 14:45:37 - error: [Error: Component JSON file "/home/ed/client/bower_components/ember-sockets/.bower.json" must have `main` property. See https://github.com/paulmillr/read-components#README]
```
