### PR TITLE
Moved `jasmine` to `devDependencies`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,10 @@
   "dependencies": {
     "jquery": "~2.0.3",
     "socket.io-client": "~0.9.16",
-    "jasmine": "~2.0.0",
     "handlebars": "~1.3.0",
     "ember": "~1.5.0"
+  },
+  "devDependencies": {
+    "jasmine": "~2.0.0"
   }
 }


### PR DESCRIPTION
As jasmine is only used for development and unit testing it has been moved to "devDependencies" which allows for ember-sockets to be installed without requiring jasmine by using the `--production` argument when running bower (i.e., `bower install ember-sockets --production`)
