### PR TITLE
change referred ember-sockets.js to right src

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="js/vendor/handlebars/handlebars.js"></script>
     <script type="text/javascript" src="js/vendor/ember/ember.js"></script>
 
-    <script type="text/javascript" src="js/vendor/ember-sockets/ember-sockets.js"></script>
+    <script type="text/javascript" src="../dist/ember-sockets.js"></script>
     <script type="text/javascript" src="js/application.js"></script>
     <script type="text/javascript" src="js/controller.js"></script>
     <link rel="stylesheet" type="text/css" href="css/default.css" />


### PR DESCRIPTION
example is not working as the js didn't exist in src `js/vendor/ember-sockets/ember-sockets.js`, fixed by point to the one locate in parent folder.
