### PR TITLE
no need grunt install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Example
 Install EmberSockets:
 
  * `npm install`;
+ * `bower install`;
  * `grunt build`;
 
 You need Node.js installed to use the example.
 
-If you have it installed, you can simply run `node example/server.js` and then open `localhost/example/index.html` in your web-browser.
+If you have it installed, you can simply run `node example/server.js` and then open the file `example/index.html` with your web-browser.
 
 Getting Started
 ------------


### PR DESCRIPTION
no task `install` in Grunt config, run `grunt  install` will report below error:  

``` sh
22:41 $ grunt install
Warning: Task "install" not found. Use --force to continue.

Aborted due to warnings.
```

which is confusing and it is not necessary,  so i deleted it from README.
